### PR TITLE
Remove extraneous space before exclamation mark

### DIFF
--- a/battletest.py
+++ b/battletest.py
@@ -72,5 +72,5 @@ def battletest():
 
     print "You won!"
     ennemy_dead = True
-    print "She crumbles to the ground, now that was a fight !"
+    print "She crumbles to the ground, now that was a fight!"
 battletest()


### PR DESCRIPTION
This simple PR removes an extraneous space that was left before an exclamation mark.

Probably a French vs English punctuation thing...